### PR TITLE
fix RSA key generation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 2. As of now `termux-keystore` cannot generate keys compatible with tergent. Use one of these commands instead:
   - To generate an RSA key:
 ```
-/data/data/com.termux/files/usr/libexec/termux-api Keystore -e command generate -e alias ALIAS -e algorithm ALGORITHM --ei purposes 12 --esa digests NONE,SHA-1,SHA-256,SHA-384,SHA-512 --ei size SIZE --ei validity VALIDITY
+/data/data/com.termux/files/usr/libexec/termux-api Keystore -e command generate -e alias ALIAS -e algorithm RSA --ei purposes 12 --esa digests NONE,SHA-1,SHA-256,SHA-384,SHA-512 --ei size SIZE --ei validity VALIDITY
 ```
   - To generate an EC key:
 ```


### PR DESCRIPTION
before:
```sh
$ /data/data/com.termux/files/usr/libexec/termux-api Keystore ... -e algorithm ALGORITHM ...
$ ssh-keygen -D $PREFIX/lib/libtergent.so
Enter PIN for 'tergent':
PKCS#11 login failed: error 84
login failed
cannot read public key from pkcs11
```

after:
```
$ /data/data/com.termux/files/usr/libexec/termux-api Keystore ... -e algorithm RSA ...
$ ssh-keygen -D $PREFIX/lib/libtergent.so
ssh-rsa ...
```

https://github.com/aeolwyr/tergent/issues/11